### PR TITLE
Improve collection search and tests

### DIFF
--- a/pkg/persistence/collection.go
+++ b/pkg/persistence/collection.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -215,15 +216,9 @@ type SearchResult struct {
 
 // SortSearchResults sorts search results by distance (ascending)
 func SortSearchResults(results []SearchResult) {
-	// Simple bubble sort for now
-	n := len(results)
-	for i := 0; i < n-1; i++ {
-		for j := 0; j < n-i-1; j++ {
-			if results[j].Distance > results[j+1].Distance {
-				results[j], results[j+1] = results[j+1], results[j]
-			}
-		}
-	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Distance < results[j].Distance
+	})
 }
 
 // Count returns the number of vectors in the collection

--- a/pkg/persistence/collection_benchmark_test.go
+++ b/pkg/persistence/collection_benchmark_test.go
@@ -1,0 +1,52 @@
+package persistence
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/TFMV/quiver/pkg/vectortypes"
+)
+
+func setupBenchmarkCollection(numVectors, dim int) *Collection {
+	c := NewCollection("bench", dim, vectortypes.EuclideanDistance)
+	vec := make([]float32, dim)
+	for i := 0; i < numVectors; i++ {
+		id := fmt.Sprintf("v%d", i)
+		for j := range vec {
+			vec[j] = float32((i+j)%dim) / 100.0
+		}
+		c.AddVector(id, append([]float32(nil), vec...), nil)
+	}
+	return c
+}
+
+func BenchmarkCollectionSearch(b *testing.B) {
+	const numVectors = 1000
+	const dim = 32
+	c := setupBenchmarkCollection(numVectors, dim)
+	query := make([]float32, dim)
+	for i := range query {
+		query[i] = 0.5
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = c.Search(query, 10)
+	}
+}
+
+func BenchmarkSortSearchResults(b *testing.B) {
+	const numResults = 1000
+	results := make([]SearchResult, numResults)
+	for i := 0; i < numResults; i++ {
+		results[i] = SearchResult{
+			ID:       fmt.Sprintf("v%d", i),
+			Distance: float32(numResults - i),
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		SortSearchResults(results)
+	}
+}

--- a/pkg/persistence/collection_test.go
+++ b/pkg/persistence/collection_test.go
@@ -583,3 +583,29 @@ func TestFacetFields(t *testing.T) {
 		t.Errorf("Expected only v3 in results, got %v", results)
 	}
 }
+
+func TestSearchWithFacetsDimensionMismatch(t *testing.T) {
+	c := NewCollection("mismatch", 3, vectortypes.CosineDistance)
+	c.SetFacetFields([]string{"type"})
+	if err := c.AddVector("v1", []float32{0.1, 0.2, 0.3}, map[string]string{"type": "a"}); err != nil {
+		t.Fatalf("failed to add vector: %v", err)
+	}
+	_, err := c.SearchWithFacets([]float32{0.1, 0.2}, 1, nil)
+	if err == nil {
+		t.Fatal("expected error for query dimension mismatch")
+	}
+}
+
+func TestSearchWithFacetsNoResults(t *testing.T) {
+	c := NewCollection("noresults", 3, vectortypes.CosineDistance)
+	c.SetFacetFields([]string{"type"})
+	c.AddVector("v1", []float32{1, 0, 0}, map[string]string{"type": "a"})
+	filters := []facets.Filter{&facets.EqualityFilter{FieldName: "type", Value: "b"}}
+	res, err := c.SearchWithFacets([]float32{1, 0, 0}, 5, filters)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("expected no results, got %d", len(res))
+	}
+}


### PR DESCRIPTION
## Summary
- optimize sorting of search results
- add benchmarks for collection search and sorting
- test facet search edge cases

## Testing
- `go test ./...` *(fails: fetching modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68530411c6a8832eafda7cfc55fb6724