### PR TITLE
Improve persistence collection safety

### DIFF
--- a/pkg/persistence/collection_benchmark_test.go
+++ b/pkg/persistence/collection_benchmark_test.go
@@ -50,3 +50,19 @@ func BenchmarkSortSearchResults(b *testing.B) {
 		SortSearchResults(results)
 	}
 }
+
+func BenchmarkCollectionAddVector(b *testing.B) {
+	const dim = 32
+	c := NewCollection("bench_add", dim, vectortypes.EuclideanDistance)
+	vec := make([]float32, dim)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		id := fmt.Sprintf("v%d", i)
+		for j := range vec {
+			vec[j] = float32((i+j)%dim) / 100.0
+		}
+		if err := c.AddVector(id, vec, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- copy vectors and metadata when storing or returning
- validate distance function and query inputs before searching
- ensure returned collections are immutable
- benchmark collection AddVector performance
- add tests covering immutability of collection data

## Testing
- `go test ./...` *(fails: fetching modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685305102f80832e9dc605fd7f589e9a