### PR TITLE
Add squared distance and benchmarks

### DIFF
--- a/pkg/vectortypes/benchmark_test.go
+++ b/pkg/vectortypes/benchmark_test.go
@@ -1,0 +1,23 @@
+package vectortypes
+
+import "testing"
+
+func benchmarkDistance(b *testing.B, fn DistanceFunc) {
+	dim := 128
+	a := make(F32, dim)
+	c := make(F32, dim)
+	for i := 0; i < dim; i++ {
+		a[i] = float32(i) * 0.01
+		c[i] = float32(i+1) * 0.02
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = fn(a, c)
+	}
+}
+
+func BenchmarkCosineDistance(b *testing.B)           { benchmarkDistance(b, CosineDistance) }
+func BenchmarkEuclideanDistance(b *testing.B)        { benchmarkDistance(b, EuclideanDistance) }
+func BenchmarkSquaredEuclideanDistance(b *testing.B) { benchmarkDistance(b, SquaredEuclideanDistance) }
+func BenchmarkDotProductDistance(b *testing.B)       { benchmarkDistance(b, DotProductDistance) }
+func BenchmarkManhattanDistance(b *testing.B)        { benchmarkDistance(b, ManhattanDistance) }

--- a/pkg/vectortypes/distances.go
+++ b/pkg/vectortypes/distances.go
@@ -54,6 +54,23 @@ func EuclideanDistance(a, b F32) float32 {
 	return float32(math.Sqrt(sum))
 }
 
+// SquaredEuclideanDistance calculates the squared Euclidean distance between vectors
+// This avoids the final square root which can be useful in comparisons where only
+// relative ordering matters.
+func SquaredEuclideanDistance(a, b F32) float32 {
+	if len(a) != len(b) {
+		panic("vectors must have the same length")
+	}
+
+	var sum float32
+	for i := 0; i < len(a); i++ {
+		diff := a[i] - b[i]
+		sum += diff * diff
+	}
+
+	return sum
+}
+
 // DotProductDistance calculates negative dot product as a distance
 // For normalized vectors, higher dot product indicates higher similarity
 // We negate this to make it a distance (where lower values = more similar)
@@ -88,10 +105,11 @@ func ManhattanDistance(a, b F32) float32 {
 
 // Create surfaces for the standard distance functions
 var (
-	CosineSurface     = CreateSurface(CosineDistance)
-	EuclideanSurface  = CreateSurface(EuclideanDistance)
-	DotProductSurface = CreateSurface(DotProductDistance)
-	ManhattanSurface  = CreateSurface(ManhattanDistance)
+	CosineSurface           = CreateSurface(CosineDistance)
+	EuclideanSurface        = CreateSurface(EuclideanDistance)
+	SquaredEuclideanSurface = CreateSurface(SquaredEuclideanDistance)
+	DotProductSurface       = CreateSurface(DotProductDistance)
+	ManhattanSurface        = CreateSurface(ManhattanDistance)
 )
 
 // NormalizeVector normalizes a vector to unit length

--- a/pkg/vectortypes/distances_test.go
+++ b/pkg/vectortypes/distances_test.go
@@ -86,6 +86,43 @@ func TestEuclideanDistance(t *testing.T) {
 	}
 }
 
+func TestSquaredEuclideanDistance(t *testing.T) {
+	tests := []struct {
+		name     string
+		vecA     F32
+		vecB     F32
+		expected float32
+	}{
+		{
+			name:     "Identical Vectors",
+			vecA:     F32{1, 0, 0},
+			vecB:     F32{1, 0, 0},
+			expected: 0,
+		},
+		{
+			name:     "Unit Vectors",
+			vecA:     F32{1, 0, 0},
+			vecB:     F32{0, 1, 0},
+			expected: 2,
+		},
+		{
+			name:     "3D Vectors",
+			vecA:     F32{1, 2, 3},
+			vecB:     F32{4, 5, 6},
+			expected: 27,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SquaredEuclideanDistance(tt.vecA, tt.vecB)
+			if !floatEquals(result, tt.expected, 1e-6) {
+				t.Errorf("SquaredEuclideanDistance(%v, %v) = %v, want %v", tt.vecA, tt.vecB, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestDotProductDistance(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -174,6 +211,7 @@ func TestDistanceFunctionPanics(t *testing.T) {
 	}{
 		{"CosineDistance", CosineDistance},
 		{"EuclideanDistance", EuclideanDistance},
+		{"SquaredEuclideanDistance", SquaredEuclideanDistance},
 		{"DotProductDistance", DotProductDistance},
 		{"ManhattanDistance", ManhattanDistance},
 	}


### PR DESCRIPTION
## Summary
- support squared Euclidean distance calculations
- expose SquaredEuclideanSurface
- test SquaredEuclideanDistance and panic conditions
- benchmark distance functions

## Testing
- `go test ./...` *(fails: failed to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_685306b34590832ea611acb5771b2377