### PR TITLE
Validate dimension in CreateCollection

### DIFF
--- a/pkg/core/db.go
+++ b/pkg/core/db.go
@@ -284,6 +284,11 @@ func (db *DB) CreateCollection(name string, dimension int, distanceFunc vectorty
 		return nil, fmt.Errorf("%w: %s", ErrCollectionExists, name)
 	}
 
+	// Validate dimension
+	if dimension <= 0 {
+		return nil, ErrInvalidDimension
+	}
+
 	var index Index
 	// Default distance function name for persistence
 	var distFuncName string = "cosine"

--- a/pkg/core/db_test.go
+++ b/pkg/core/db_test.go
@@ -216,6 +216,16 @@ func TestDB_CreateCollection(t *testing.T) {
 		}
 	})
 
+	t.Run("Create Collection With Invalid Dimension", func(t *testing.T) {
+		_, err := db.CreateCollection("invalid_dim", 0, vectortypes.GetSurfaceByType(vectortypes.Cosine))
+		if err == nil {
+			t.Error("expected error for dimension <= 0")
+		}
+		if !errors.Is(err, ErrInvalidDimension) {
+			t.Errorf("CreateCollection() error = %v, want %v", err, ErrInvalidDimension)
+		}
+	})
+
 	t.Run("Create Collection with Different Distance Functions", func(t *testing.T) {
 		tests := []struct {
 			name           string


### PR DESCRIPTION
## Summary
- validate dimension when creating a collection
- test for invalid dimension error

## Testing
- `go test ./...` *(fails: github.com/prometheus/client_golang v1.22.0: Get "https://proxy.golang.org/..." Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68530c861c08832eb61cca559aa9fad1